### PR TITLE
[Postgres] Support for Boolean & Text Event Fields

### DIFF
--- a/src/database/postgres.rs
+++ b/src/database/postgres.rs
@@ -562,7 +562,7 @@ event Event (
             fields: vec![
                 AbiValue::Bool(true),
                 AbiValue::Bool(false),
-                AbiValue::String("hello".to_string()),
+                AbiValue::String("zef".to_string()),
             ],
             ..Default::default()
         };

--- a/src/database/postgres.rs
+++ b/src/database/postgres.rs
@@ -335,7 +335,7 @@ impl Postgres {
                         .collect::<Vec<_>>(),
                 ),
                 VisitValue::Value(AbiValue::Bytes(v)) => Box::new(v.to_owned()),
-                VisitValue::Value(AbiValue::String(v)) => Box::new(v.as_bytes().to_vec()),
+                VisitValue::Value(AbiValue::String(v)) => Box::new(v.to_string()),
                 _ => unreachable!(),
             };
             (if in_array {
@@ -417,7 +417,7 @@ impl Postgres {
                 unhandled_type => {
                     tracing::debug!("Got Type {}", unhandled_type);
                     unreachable!()
-                },
+                }
             };
             write!(&mut sql, " {type_}, ").unwrap();
         }

--- a/src/database/postgres.rs
+++ b/src/database/postgres.rs
@@ -544,13 +544,14 @@ event Event (
 
     #[ignore]
     #[tokio::test]
-    async fn boolean_fields() {
+    async fn boolean_and_text_fields() {
         clear_database().await;
         let mut db = Postgres::connect(&local_postgres_url()).await.unwrap();
         let event = r#"
 event Event (
     bool,
-    bool
+    bool,
+    string
 )
 "#;
         let event = EventDescriptor::parse_declaration(event).unwrap();
@@ -558,7 +559,11 @@ event Event (
         let log = Log {
             event: "event",
             block_number: 0,
-            fields: vec![AbiValue::Bool(true), AbiValue::Bool(false)],
+            fields: vec![
+                AbiValue::Bool(true),
+                AbiValue::Bool(false),
+                AbiValue::String("hello".to_string()),
+            ],
             ..Default::default()
         };
         db.update(&[], &[log]).await.unwrap();

--- a/src/database/postgres.rs
+++ b/src/database/postgres.rs
@@ -413,7 +413,11 @@ impl Postgres {
                 tokio_postgres::types::Type::BYTEA => "BYTEA",
                 tokio_postgres::types::Type::NUMERIC => "NUMERIC",
                 tokio_postgres::types::Type::BOOL => "BOOLEAN",
-                _ => unreachable!(),
+                tokio_postgres::types::Type::TEXT => "TEXT",
+                unhandled_type => {
+                    tracing::debug!("Got Type {}", unhandled_type);
+                    unreachable!()
+                },
             };
             write!(&mut sql, " {type_}, ").unwrap();
         }

--- a/src/database/postgres.rs
+++ b/src/database/postgres.rs
@@ -412,6 +412,7 @@ impl Postgres {
                 tokio_postgres::types::Type::INT8 => "INT8",
                 tokio_postgres::types::Type::BYTEA => "BYTEA",
                 tokio_postgres::types::Type::NUMERIC => "NUMERIC",
+                tokio_postgres::types::Type::BOOL => "BOOLEAN",
                 _ => unreachable!(),
             };
             write!(&mut sql, " {type_}, ").unwrap();


### PR DESCRIPTION
When trying to index the following event type:

```
[[event]]
name = "approval_for_all"
start = 7846500
contract = "*"
signature = "event ApprovalForAll(address indexed owner, address indexed operator, bool approved)"

[[event]]
name = "erc1155_uri"
start = 10000000
contract = "*"
signature = "event URI(string value, uint256 indexed id)"
```

we reached an `unreachable code point` (this is because boolean and text was not previously caught in the match statement).

After naively adding the support in the match statement that was previously reaching and `unreachable!` part of the code, we got type conversion errors:

```
cannot convert between the Rust type `i64` and the Postgres type `bool` (For Boolean Types)
cannot convert between the Rust type `alloc::vec::Vec<u8>` and the Postgres type `text` (for Text types)
```
Both of these have now been resolved.

## Test Plan

Added an ignored test that worked with `docker-compose up` followed by running the test.


Or try [the GIST](https://gist.github.com/bh2smith/3d8a443f26b1130722e2e6fbb6ffe2e3)

Set the start block number to `10000000` instead of 0 so to see some actual events.

