### PR TITLE
[Easy] Byte String Bug

### DIFF
--- a/src/database/postgres.rs
+++ b/src/database/postgres.rs
@@ -335,7 +335,9 @@ impl Postgres {
                         .collect::<Vec<_>>(),
                 ),
                 VisitValue::Value(AbiValue::Bytes(v)) => Box::new(v.to_owned()),
-                VisitValue::Value(AbiValue::String(v)) => Box::new(v.to_string()),
+                VisitValue::Value(AbiValue::String(v)) => {
+                    Box::new(v.trim_matches('\0').to_string())
+                }
                 _ => unreachable!(),
             };
             (if in_array {
@@ -562,7 +564,7 @@ event Event (
             fields: vec![
                 AbiValue::Bool(true),
                 AbiValue::Bool(false),
-                AbiValue::String("zef".to_string()),
+                AbiValue::String("zef with trailing null bytes\0".to_string()),
             ],
             ..Default::default()
         };


### PR DESCRIPTION
Over the weekend we ran into an issue indexing the following events:

```
[[event]]
name = "erc1155_uri"
start = 6938760
contract = "0xD0E4847359ae76C2786D242e5F45C4f6F1aBd752"
signature = "event URI(string value, uint256 indexed id)"
```

Primarily because of [this transaction](https://etherscan.io/tx/0xbfade86a681609f4e07a3b1456bdc5f34629aa9ac9082faf7d22358dc00a659f#eventlog)

because the URI was in the middle of the 

<details><summary> "data" field (see first event log)</summary>

0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000005568747470733a2f2f6170692e63727970746f70696f6e656572732e636f2f7265736f757263652f746f6b656e3f746f6b656e49643d00000000000000000000000000000000000000000000000000000000000000000000000000000000000000
</details>

Which translates into the rust string (having trailing null bytes).

```rs
"https://api.cryptopioneers.co/resource/token?tokenId=\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
```
This PR trims null bytes off the string and no longer fails DB inserts.


### Test Plan

1. Updated Unit test (to include null bytes)

To see the error run the program off of main with the following local config:

```toml
ethrpc = "https://eth.llamarpc.com"

[database.postgres]
connection = "postgresql://arak:123@localhost:5432/postgres"

[indexer]
page-size = 2
poll-interval = 0.1

[[event]]
name = "erc1155_uri"
start = 6938760
contract = "0xD0E4847359ae76C2786D242e5F45C4f6F1aBd752"
signature = "event URI(string value, uint256 indexed id)"
```

Then check out this branch and try it here!

```sh
RUST_LOG=debug,arak=debug cargo run
```