### PR TITLE
Env Secrets (Node & DB Credentials)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+NODE_URL=https://rpc.ankr.com/eth
+
+# DB credentials created with `docker-compose up`
+DB_STRING=postgresql://arak:123@localhost:5432/postgres

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /arak.toml
+/.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "dotenv",
  "ethrpc",
  "futures",
  "hex-literal",
@@ -283,6 +284,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "encoding_rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ url = { version = "2", features = ["serde"] }
 futures = "0.3"
 tokio-postgres = "0.7"
 pg_bigdecimal = "0.1.5"
+dotenv = "0.15.0"
 
 [dev-dependencies]
 hex-literal = "0.4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,8 +65,12 @@ pub enum Contract {
 impl Config {
     /// Reads a configuration from the specified path, returning the parsed
     /// configuration and its root path.
-    pub fn load(path: &Path) -> Result<(Self, PathBuf)> {
-        let toml = fs::read_to_string(path)?;
+    pub fn load(
+        path: &Path,
+        node_url: Option<String>,
+        db_url: Option<String>,
+    ) -> Result<(Self, PathBuf)> {
+        let toml = manual_override(fs::read_to_string(path)?, node_url, db_url);
         let config = toml::from_str(&toml)?;
         let root = fs::canonicalize(path)?
             .parent()
@@ -74,6 +78,31 @@ impl Config {
             .to_owned();
         Ok((config, root))
     }
+}
+
+fn manual_override(mut toml: String, node_url: Option<String>, db_url: Option<String>) -> String {
+    // override for node_url
+    if let Some(ethrpc) = node_url {
+        tracing::info!("using env NODE_URL");
+        // comment any existing config
+        toml = toml.replace("ethrpc", "#ethrpc");
+        // Insert the new one at the top
+        toml = format!("ethrpc = \"{ethrpc}\"\n") + &toml;
+    }
+    // override for db_url
+    if let Some(connection) = db_url {
+        tracing::info!("using env DB_URL");
+        // comment any existing config
+        toml = toml.replace("[database.", "#[database.");
+        let db_type = if connection.contains("file:") {
+            "sqlite"
+        } else {
+            "postgres"
+        };
+        // Append the new one at the bottom.
+        toml = toml + &format!("\n[database.{db_type}]\nconnection = \"{connection}\"");
+    }
+    toml
 }
 
 impl Debug for Config {
@@ -165,5 +194,83 @@ impl Event {
             topics: ArrayVec::new(),
             signature,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_manual_override() {
+        // Sample contains both ethrpc and database.sqlite config
+        let sample_toml = fs::read_to_string("arak.example.toml").unwrap();
+        let sample_config: Config = toml::from_str(&sample_toml).unwrap();
+        let sample_node_url = Url::parse("http://localhost:8545").unwrap();
+        assert_eq!(sample_config.ethrpc, sample_node_url);
+        match sample_config.database {
+            Database::Postgres { .. } => panic!("Expected sqlite"),
+            Database::Sqlite { .. } => (),
+        }
+
+        // Manual (Env) Values
+        let node_url = Some("https://url.com".to_string());
+        let db_url = Some("postgres://DB_URL".to_string());
+
+        // override both
+        let config: Config = toml::from_str(&manual_override(
+            sample_toml.clone(),
+            node_url.clone(),
+            db_url.clone(),
+        ))
+        .unwrap();
+        assert_eq!(
+            config.ethrpc,
+            Url::parse(&node_url.clone().unwrap()).unwrap()
+        );
+        match config.database {
+            Database::Postgres { .. } => (),
+            Database::Sqlite { .. } => panic!("Expected postgres"),
+        }
+
+        // only node_url
+        let config: Config = toml::from_str(&manual_override(
+            sample_toml.clone(),
+            node_url.clone(),
+            None,
+        ))
+        .unwrap();
+        assert_eq!(
+            config.ethrpc,
+            Url::parse(&node_url.clone().unwrap()).unwrap()
+        );
+        match config.database {
+            Database::Postgres { .. } => panic!("Expected sqlite"),
+            Database::Sqlite { .. } => (),
+        }
+
+        // only db_url
+        let config: Config =
+            toml::from_str(&manual_override(sample_toml.clone(), None, db_url.clone())).unwrap();
+        assert_eq!(config.ethrpc, sample_node_url);
+        match config.database {
+            Database::Postgres { .. } => (),
+            Database::Sqlite { .. } => panic!("Expected postgres"),
+        }
+
+        // toml without node or db provided
+        let my_toml = r#"
+            [[event]]
+            name = "crypto_kitty_mints"
+            start = 4605160
+            contract = "0x06012c8cf97bead5deae237070f9587f8e7a266d"
+            topics = [
+                "0x0000000000000000000000000000000000000000000000000000000000000000"
+            ]
+            signature = "event Transfer (address from, address to, uint256 tokenId)""#;
+        assert!(
+            toml::from_str::<Config>(&manual_override(my_toml.to_string(), node_url, db_url))
+                .is_ok()
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use database::Database;
-
+use dotenv::dotenv;
 mod config;
 mod database;
 mod indexer;
@@ -15,14 +15,20 @@ use {
 struct Arguments {
     #[clap(short, long, env = "ARAKCONFIG", default_value = "arak.toml")]
     config: PathBuf,
+    #[clap(short, long, env = "DB_STRING")]
+    db_string: Option<String>,
+    #[clap(short, long, env = "NODE_URL")]
+    node_url: Option<String>,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
-
+    dotenv().ok(); // Couldn't load multiple Env Vars without this!
     let args = Arguments::parse();
-    let (config, root) = Config::load(&args.config).context("failed to load configuration")?;
+
+    let (config, root) = Config::load(&args.config, args.node_url, args.db_string)
+        .context("failed to load configuration")?;
     env::set_current_dir(root)?;
 
     match &config.database {


### PR DESCRIPTION
In order to streamline the deployment process, we make it possible to pass db and node credentials as ENV vars to the container. This is done by "manually overriding" the toml configuration when env vars are provided (so the environment variables "trump" having the data in the config toml file).

Note that this change is backwards compatible with the originally intended functionality, but we can phase this out over time if we like.

## Test Plan

There is a comprehensive unit test of the manual override method demonstrating expected functionality in boolean cases where env vars are `Some` or `None`.