### PR TITLE
Fix Logs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ async fn main() -> Result<()> {
     dotenv().ok(); // Couldn't load multiple Env Vars without this!
     let args = Arguments::parse();
     let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(env::var("RUST_LOGS").unwrap_or("info,arak=debug".to_string()))
         .with_ansi(false)
         .finish();
 


### PR DESCRIPTION
In a previous PR -- we actually lost the logs by removing the declaration from the tracing subscriber. This puts them back and allows user to configure them as they would usually (with `RUST_LOG` env variable). 


## Test Plan 

`cargo run` is the same as ` RUST_LOG=info,arak=debug cargo run`