### PR TITLE
Synced Config

### DIFF
--- a/kubernetes/config/configmap.yaml
+++ b/kubernetes/config/configmap.yaml
@@ -7,8 +7,8 @@ data:
   arak.toml: |
 
     [indexer]
-    page-size = 2000
-    poll-interval = 0.1
+    page-size = 1000
+    poll-interval = 5
 
     ## ERC721: https://eips.ethereum.org/EIPS/eip-721#specification
     [[event]]

--- a/kubernetes/config/configmap.yaml
+++ b/kubernetes/config/configmap.yaml
@@ -8,7 +8,7 @@ data:
 
     [indexer]
     page-size = 1000
-    poll-interval = 5
+    poll-interval = 10
 
     ## ERC721: https://eips.ethereum.org/EIPS/eip-721#specification
     [[event]]


### PR DESCRIPTION
Now that we are synced, we only need to poll for new blocks every 10s. I ran this for 48 hours with 5 second polling, but we were really hitting a high number of requests. Since this isn't in production yet we could probably even reduce it further, but its nice to have some metrics on how many requests we make per day at a few different polling intervals. 


These changes have already been applied to our existing pod service.
