### PR TITLE
Make All Event Fields Not Null

### DIFF
--- a/src/database/postgres.rs
+++ b/src/database/postgres.rs
@@ -419,7 +419,7 @@ impl Postgres {
                     unreachable!()
                 }
             };
-            write!(&mut sql, " {type_}, ").unwrap();
+            write!(&mut sql, " {type_} NOT NULL, ").unwrap();
         }
         let primary_key = if is_array {
             PRIMARY_KEY_ARRAY

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -274,7 +274,7 @@ impl SqliteInner {
                     SqlType::Text => "TEXT",
                     SqlType::Blob => "BLOB",
                 };
-                write!(&mut sql, " {type_}, ").unwrap();
+                write!(&mut sql, " {type_} NOT NULL, ").unwrap();
             }
             let primary_key = if is_array {
                 PRIMARY_KEY_ARRAY


### PR DESCRIPTION
We had a very messy interface with a bunch of really ugly "expect" statements because it is never the case that event fields are NULL. This change will dramatically improve working with an arak database, but we will have to (one time). manually alter the existing database as follows:

```
for table in all_existing_tables {
    for all column in table.columns {
          ALTER TABLE table ALTER COLUMN column SET NOT NULL
    }
}
```

This will involve the following migration file according to our existing `arak.toml` configuration:

```sql

-- 34 ms
ALTER TABLE approval_for_all
    ALTER COLUMN address SET NOT NULL,
    ALTER COLUMN owner_0 SET NOT NULL,
    ALTER COLUMN operator_1 SET NOT NULL,
    ALTER COLUMN approved_2 SET NOT NULL;

-- 104 ms
ALTER TABLE erc721_approval
    ALTER COLUMN address SET NOT NULL,
    ALTER COLUMN owner_0 SET NOT NULL,
    ALTER COLUMN approved_1 SET NOT NULL,
    ALTER COLUMN tokenid_2 SET NOT NULL;

-- 157 ms
-- THIS SHOULD BE DONE LAST!
ALTER TABLE erc721_transfer
    ALTER COLUMN address SET NOT NULL,
    ALTER COLUMN from_0 SET NOT NULL,
    ALTER COLUMN to_1 SET NOT NULL,
    ALTER COLUMN tokenid_2 SET NOT NULL;

-- 10 ms
ALTER TABLE erc1155_transfer_batch
    ALTER COLUMN address SET NOT NULL,
    ALTER COLUMN operator_0 SET NOT NULL,
    ALTER COLUMN from_1 SET NOT NULL,
    ALTER COLUMN to_2 SET NOT NULL;

-- 26 ms
ALTER TABLE erc1155_transfer_batch_ids_0
    ALTER COLUMN address SET NOT NULL,
    ALTER COLUMN array_index SET NOT NULL,
    ALTER COLUMN ids_0 SET NOT NULL;

-- 30 ms
ALTER TABLE erc1155_transfer_batch_values_1
    ALTER COLUMN address SET NOT NULL,
    ALTER COLUMN array_index SET NOT NULL,
    ALTER COLUMN values_0 SET NOT NULL;

-- 10 ms
ALTER TABLE erc1155_uri
    ALTER COLUMN address SET NOT NULL,
    ALTER COLUMN value_0 SET NOT NULL,
    ALTER COLUMN id_1 SET NOT NULL;
```