### PR TITLE
Use Postgres User in Test Compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,8 +6,9 @@ services:
     restart: always
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
-      POSTGRES_USER: arak
-      POSTGRES_PASSWORD: 123
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: arak
     command: -d postgres
     volumes:
       - postgres:/var/lib/postgresql/data

--- a/src/database/postgres.rs
+++ b/src/database/postgres.rs
@@ -499,7 +499,7 @@ mod tests {
     use super::*;
 
     fn local_postgres_url() -> String {
-        "postgresql://arak@localhost".to_string()
+        "postgresql://postgres@localhost".to_string()
     }
 
     async fn clear_database() {


### PR DESCRIPTION
In order to align with evm-indexer - particularly for [these new instructions](https://github.com/Mintbase/evm-indexer/pull/34) we adjust the db credentials for the test setup.


## Test Plan

Existing CI works. Furthermore, there are two ignored DB tests in this repo that when run also pass.