### PR TITLE
Add db-schema config

### DIFF
--- a/arak.example.toml
+++ b/arak.example.toml
@@ -5,6 +5,10 @@ ethrpc = "http://localhost:8545"
 [database.sqlite]
 connection = "file:arak.db"
 
+#[database.postgres]
+#connection = "postgresql://postgres:postgres@localhost:5432/arak"
+#schema = "local"
+
 [[event]]
 name = "cowprotocol_settlements"
 start = 12593265

--- a/kubernetes/config/configmap.yaml
+++ b/kubernetes/config/configmap.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Namespace }}
 data:
   arak.toml: |
+    
+    [database.postgres]
+    schema = "mainnet"
 
     [indexer]
     page-size = 200

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,7 @@ pub struct Config {
 #[serde(rename_all = "kebab-case")]
 pub enum Database {
     Sqlite { connection: String },
-    Postgres { connection: String },
+    Postgres { connection: String, schema: String },
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,8 +39,12 @@ async fn main() -> Result<()> {
         config::Database::Sqlite { connection } => {
             run_indexer(&config, database::Sqlite::open(connection)?).await?;
         }
-        config::Database::Postgres { connection } => {
-            run_indexer(&config, database::Postgres::connect(connection).await?).await?;
+        config::Database::Postgres { connection, schema } => {
+            run_indexer(
+                &config,
+                database::Postgres::connect(connection, schema).await?,
+            )
+            .await?;
         }
     }
 


### PR DESCRIPTION
In alignment with https://github.com/Mintbase/evm-indexer/pull/120, we add a schema configuration to the arak event-listening service. 

This will require a change to our existing deployment:

Namely 

1. Service shut down

```
cd kubernetes
make delete
```

2. Alter schema query

```sql
ALTER SCHEMA public RENAME TO mainnet;
```

3. Restart service (with new configuration)

```sh
make apply
```

