### PR TITLE
Update GH Actions

### DIFF
--- a/.github/workflows/deploy-google.yaml
+++ b/.github/workflows/deploy-google.yaml
@@ -11,15 +11,15 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Google Cloud CLI
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: Set up docker auth
         run: gcloud auth configure-docker

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,18 +14,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v3
+      - uses: docker/metadata-action@v4
         id: meta
         with:
           images: ghcr.io/${{ github.repository }}
 
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v4
         with:
           context: .
           file: docker/Dockerfile

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Lint
       run: cargo fmt --check && cargo clippy --all-targets --verbose
     - name: Test


### PR DESCRIPTION
There were several warnings on our actions that we attempt to resolve by bumping versions:


Warnings:
- [deploy](https://github.com/Mintbase/arak/actions/runs/7613646816)
- [rust](https://github.com/Mintbase/arak/actions/runs/7613646809)
- [deploy GCP](https://github.com/Mintbase/arak/actions/runs/7613646808)