### PR TITLE
Update Dependencies for Gnosis Chain Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "ethrpc"
 version = "0.0.8"
-source = "git+https://github.com/bh2smith/ethrpc-rs?rev=04ba07064fcb9ac8cf71e02d2c168819499b3616#04ba07064fcb9ac8cf71e02d2c168819499b3616"
+source = "git+https://github.com/bh2smith/ethrpc-rs?rev=4eb7466#4eb74661d48d01ef8224b853ef57f91cca69abdc"
 dependencies = [
  "arrayvec",
  "ethprim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ clap = { version = "4", features = ["derive", "env"] }
 rusqlite = { version = "0.30.0", features = ["extra_check"] }
 # Waiting on https://github.com/nlordell/ethrpc-rs/pull/9
 #ethrpc = { version = "0.0.8", features = ["http"] }
-ethrpc = { git = "https://github.com/bh2smith/ethrpc-rs", rev = "04ba07064fcb9ac8cf71e02d2c168819499b3616", features = [
+ethrpc = { git = "https://github.com/bh2smith/ethrpc-rs", rev = "4eb7466", features = [
     "http",
 ] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Some of the type declarations were not compatible with Gnosis Chain. See related code changes that resolved the issue:

https://github.com/bh2smith/ethrpc-rs/pull/2