### PR TITLE
[WIP] Hack Base Indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "ethrpc"
 version = "0.0.8"
-source = "git+https://github.com/bh2smith/ethrpc-rs?rev=4eb7466#4eb74661d48d01ef8224b853ef57f91cca69abdc"
+source = "git+https://github.com/bh2smith/ethrpc-rs?rev=f463da4#f463da4aee59c763a5ba0ac605b1441fdbbf1479"
 dependencies = [
  "arrayvec",
  "ethprim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ clap = { version = "4", features = ["derive", "env"] }
 rusqlite = { version = "0.30.0", features = ["extra_check"] }
 # Waiting on https://github.com/nlordell/ethrpc-rs/pull/9
 #ethrpc = { version = "0.0.8", features = ["http"] }
-ethrpc = { git = "https://github.com/bh2smith/ethrpc-rs", rev = "4eb7466", features = [
+ethrpc = { git = "https://github.com/bh2smith/ethrpc-rs", rev = "f463da4", features = [
     "http",
 ] }
 serde = { version = "1", features = ["derive"] }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -50,6 +50,7 @@ pub struct Uncle<'a> {
 /// An emitted event log.
 #[derive(Debug, Default)]
 pub struct Log<'a> {
+    // pub transaction_hash: Digest,
     pub event: &'a str,
     pub block_number: u64,
     pub log_index: u64,


### PR DESCRIPTION
When attempting to index base we found that blocks were SO fast it broke our indexer. Querying non-hydrated blocks helped a bit but then we lose some other data (blocks and transaction hashes).

None of this should be merged.